### PR TITLE
fix license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "steak-webapp",
   "version": "0.1.0",
   "author": "larry <gm@larry.engineer>",
-  "license": "GPL-v3-or-later",
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Should be `GPL-3.0-or-later` (see https://spdx.org/licenses/GPL-3.0-or-later.html).

https://github.com/st4k3h0us3/steak-webapp/blob/279090c7658fa104372ae154776156a36f0dbfa8/package.json#L5

![CleanShot 2022-05-06 at 19 15 00](https://user-images.githubusercontent.com/23618431/167229872-ed927184-94d0-4081-aec4-edc1ad3dd48d.png)
